### PR TITLE
Fix incorrect generation of profile url

### DIFF
--- a/lib/ueberauth/strategy/vk.ex
+++ b/lib/ueberauth/strategy/vk.ex
@@ -112,7 +112,7 @@ defmodule Ueberauth.Strategy.VK do
       location: user["city"],
       description: user["about"],
       urls: %{
-        vk: "https://vk.com/" <> to_string(user["uid"])
+        vk: "https://vk.com/id" <> to_string(user["uid"])
       }
     }
   end

--- a/test/ueberauth/strategy/vk_test.exs
+++ b/test/ueberauth/strategy/vk_test.exs
@@ -95,7 +95,7 @@ defmodule Ueberauth.Strategy.VKTest do
       description: "some info",
       image: "100.jpg",
       urls: %{
-        vk: "https://vk.com/210700286"
+        vk: "https://vk.com/id210700286"
       }
     }
   end


### PR DESCRIPTION
The correct link to user profile is https://vk.com/id1, not the https://vk.com/1