### PR TITLE
Fix 'client_secret is undefined' error

### DIFF
--- a/lib/ueberauth/strategy/vk/oauth.ex
+++ b/lib/ueberauth/strategy/vk/oauth.ex
@@ -48,6 +48,7 @@ defmodule Ueberauth.Strategy.VK.OAuth do
   def get_token!(params \\ [], opts \\ []) do
     opts
     |> client
+    |> put_param(:client_secret, client.client_secret)
     |> OAuth2.Client.get_token!(params)
   end
 


### PR DESCRIPTION
```elixir
%OAuth2.AccessToken{access_token: nil, expires_at: nil,
 other_params: %{"error" => "invalid_client",
   "error_description" => "client_secret is undefined"}, refresh_token: nil,
 token_type: "Bearer"}
```
🙇 