### PR TITLE
Ability to set state

### DIFF
--- a/lib/ueberauth/strategy/vk.ex
+++ b/lib/ueberauth/strategy/vk.ex
@@ -5,11 +5,13 @@ defmodule Ueberauth.Strategy.VK do
 
   use Ueberauth.Strategy, default_scope: "",
                           default_display: "page",
+                          default_state: "",
                           profile_fields: "",
                           uid_field: :uid,
                           allowed_request_params: [
                             :display,
-                            :scope
+                            :scope,
+                            :state
                           ]
 
   alias OAuth2.{Response, Error, Client}
@@ -30,6 +32,7 @@ defmodule Ueberauth.Strategy.VK do
       |> maybe_replace_param(conn, "auth_type", :auth_type)
       |> maybe_replace_param(conn, "scope", :default_scope)
       |> maybe_replace_param(conn, "display", :default_display)
+      |> maybe_replace_param(conn, "state", :default_state)
       |> Enum.filter(fn {k, _} -> Enum.member?(allowed_params, k) end)
       |> Enum.map(fn {k, v} -> {String.to_existing_atom(k), v} end)
       |> Keyword.put(:redirect_uri, callback_url(conn))

--- a/test/fixtures/cassettes/httpoison_get.json
+++ b/test/fixtures/cassettes/httpoison_get.json
@@ -1,7 +1,7 @@
 [
   {
     "request": {
-      "body": "client_id=appid&client_secret=secret&code=code_abc&grant_type=authorization_code&redirect_uri=http%3A%2F%2Fwww.example.com%2Fauth%2Fvk%2Fcallback",
+      "body": "client_id=appid&client_secret=secret&code=code_abc&grant_type=authorization_code&redirect_uri=http%3A%2F%2Fwww.example.com%2Fauth%2Fvk%2Fcallback&state=abc",
       "headers": {
         "Accept": "application/x-www-form-urlencoded",
         "Content-Type": "application/x-www-form-urlencoded"

--- a/test/fixtures/vk_response.html
+++ b/test/fixtures/vk_response.html
@@ -1,1 +1,1 @@
-<html><body>You are being <a href="https://oauth.vk.com/authorize?client_id=appid&amp;display=page&amp;redirect_uri=http%3A%2F%2Fwww.example.com%2Fauth%2Fvk%2Fcallback&amp;response_type=code&amp;scope=">redirected</a>.</body></html>
+<html><body>You are being <a href="https://oauth.vk.com/authorize?client_id=appid&amp;display=page&amp;redirect_uri=http%3A%2F%2Fwww.example.com%2Fauth%2Fvk%2Fcallback&amp;response_type=code&amp;scope=&amp;state=">redirected</a>.</body></html>

--- a/test/ueberauth/strategy/vk_test.exs
+++ b/test/ueberauth/strategy/vk_test.exs
@@ -56,7 +56,7 @@ defmodule Ueberauth.Strategy.VKTest do
   end
 
   test "default callback phase" do
-    query = %{code: "code_abc"} |> URI.encode_query
+    query = %{code: "code_abc", state: "abc"} |> URI.encode_query
 
     use_cassette "httpoison_get" do
       conn =


### PR DESCRIPTION
VK has ability to pass you back any string, that is set inda "state" parameter.

This can be used to save "session_id" to prevent middle attacks on the auth process.

So, redirect into `/auth/vk?state=<session_id>` should work.
After that, this state should be saved inside `success` struct