### PR TITLE
VK now requires version ("v") request field.

### DIFF
--- a/lib/ueberauth/strategy/vk.ex
+++ b/lib/ueberauth/strategy/vk.ex
@@ -181,6 +181,7 @@ defmodule Ueberauth.Strategy.VK do
       |> Map.merge(query_params(conn, :profile))
       |> Map.merge(query_params(conn, :user_id))
       |> Map.merge(query_params(conn, :access_token))
+      |> Map.merge(query_params(conn, :version))
       |> URI.encode_query
     "https://api.vk.com/method/users.get?#{query}"
   end
@@ -202,6 +203,9 @@ defmodule Ueberauth.Strategy.VK do
   end
   defp query_params(conn, :access_token) do
     %{"access_token" => conn.private.vk_token.access_token}
+  end
+  defp query_params(conn, :version) do
+    %{"v" => "5.8"}
   end
 
   defp option(conn, key) do


### PR DESCRIPTION
Without this field VK API returns error and Ueberauth fails with exception:
```
Elixir.FunctionClauseError: no function clause matching in List.first/1
  File "lib/list.ex", line 220, in List.first/1
  File "lib/ueberauth/strategy/vk.ex", line 171, in Ueberauth.Strategy.VK.fetch_user/3
  File "lib/ueberauth/strategy.ex", line 301, in Ueberauth.Strategy.run_callback/2
  File "lib/extrapost_web/controllers/auth_controller.ex", line 1, in ExtraPostWeb.AuthController.phoenix_controller_pipeline/2
```