### PR TITLE
Update OTP 20 release, remove OTP 18.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,14 +8,8 @@ elixir:
   - 1.4
 
 otp_release:
-  - 20.2
+  - 20.3
   - 19.3
-  - 18.3
-
-matrix:
-  exclude:
-    - elixir: 1.6
-      otp_release: 18.3
 
 env: MIX_ENV=test
 


### PR DESCRIPTION
Travis fails for 20 and 18 releases, cuz it cannot download images for them. 
Image for 18.3 release (which is latest) does not exist, so I consider it is not supported.
For 20 release image 20.3 exists, so we just update the version from 20.2.